### PR TITLE
libbcc debian package is architecture-dependent

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>= 9), cmake,
 Homepage: https://github.com/iovisor/bcc
 
 Package: libbcc
-Architecture: all
+Architecture: any
 Provides: libbpfcc, libbpfcc-dev
 Conflicts: libbpfcc, libbpfcc-dev
 Depends: libc6, libstdc++6, libelf1


### PR DESCRIPTION
Cherry-pick upstream change https://github.com/iovisor/bcc/pull/2746 to allow us to build a `-dbgsym` package for `libbcc`.

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2846/console