### PR TITLE
Redefine asm_inline for Linux 5.4+, Fixes #2546 (#2547)

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -17,6 +17,14 @@ R"********(
 #ifndef __BPF_HELPERS_H
 #define __BPF_HELPERS_H
 
+/* In Linux 5.4 asm_inline was introduced, but it's not supported by clang.
+ * Redefine it to just asm to enable successful compilation.
+ */
+#ifdef asm_inline
+#undef asm_inline
+#define asm_inline asm
+#endif
+
 /* Before bpf_helpers.h is included, uapi bpf.h has been
  * included, which references linux/types.h. This will bring
  * in asm_volatile_goto definition if permitted based on


### PR DESCRIPTION
Here's the upstream commit that introduced `asm_inline`:

* https://github.com/torvalds/linux/commit/eb111869301e15b737315a46c913ae82bd19eb9d

Without this patch BCC fails with the following:

```
$ sudo /usr/share/bcc/tools/opensnoop
In file included from /virtual/main.c:2:
In file included from include/uapi/linux/ptrace.h:142:
In file included from ./arch/x86/include/asm/ptrace.h:5:
./arch/x86/include/asm/segment.h:254:2: error: expected '(' after 'asm'
        alternative_io ("lsl %[seg],%[p]",
        ^
./arch/x86/include/asm/alternative.h:240:2: note: expanded from macro 'alternative_io'
        asm_inline volatile (ALTERNATIVE(oldinstr, newinstr, feature)   \
        ^
include/linux/compiler_types.h:210:24: note: expanded from macro 'asm_inline'
                       ^
```