### PR TITLE
DLPX-81527 Move bcc to python3

### DIFF
--- a/debian/bcc-tools.install
+++ b/debian/bcc-tools.install
@@ -1,3 +1,3 @@
 usr/share/bcc/introspection/*
-usr/share/bcc/tools/*
+usr/share/bcc/tools/*  usr/sbin/
 usr/share/bcc/man/*

--- a/debian/control
+++ b/debian/control
@@ -9,9 +9,9 @@ Build-Depends: debhelper (>= 9), cmake,
     libclang-9-dev | libclang-8-dev | libclang-6.0-dev | libclang-3.8-dev [!arm64] | libclang-3.7-dev [!arm64],
     clang-format-9 | clang-format-8 | clang-format-6.0 | clang-format-3.8 [!arm64] | clang-format-3.7 [!arm64] | clang-format,
     libelf-dev, bison, flex, libfl-dev, libedit-dev, zlib1g-dev, git,
-    python (>= 2.7), python-netaddr, python-pyroute2 | python3-pyroute2, luajit,
+    python3:any, python3-netaddr, python3-pyroute2, luajit,
     libluajit-5.1-dev, arping, inetutils-ping | iputils-ping, iperf, netperf,
-    ethtool, devscripts, python3, dh-python
+    ethtool, devscripts, dh-python
 # add 'libdebuginfod-dev' to Build-Depends for libdebuginfod support
 Homepage: https://github.com/iovisor/bcc
 
@@ -30,25 +30,18 @@ Architecture: any
 Depends: libbcc (= ${binary:Version})
 Description: Examples for BPF Compiler Collection (BCC)
 
-Package: python-bcc
-Architecture: all
-Provides: python-bpfcc
-Conflicts: python-bpfcc
-Depends: libbcc (= ${binary:Version}), python, binutils
-Description: Python wrappers for BPF Compiler Collection (BCC)
-
 Package: python3-bcc
 Architecture: all
 Provides: python3-bpfcc
 Conflicts: python3-bpfcc
-Depends: libbcc (= ${binary:Version}), python3, binutils
+Depends: libbcc (= ${binary:Version}), ${python3:Depends}, binutils
 Description: Python3 wrappers for BPF Compiler Collection (BCC)
 
 Package: bcc-tools
 Architecture: all
 Provides: bpfcc-tools
 Conflicts: bpfcc-tools
-Depends: python-bcc (= ${binary:Version})
+Depends: python3-bcc (= ${binary:Version}), ${python3:Depends}
 Description: Command line tools for BPF Compiler Collection (BCC)
 
 Package: bcc-lua

--- a/debian/python-bcc.install
+++ b/debian/python-bcc.install
@@ -1,1 +1,0 @@
-usr/lib/python2*

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ DEBIAN_REVISION := $(shell dpkg-parsechangelog | sed -rne "s,^Version: ([0-9.]+)
 UPSTREAM_VERSION := $(shell dpkg-parsechangelog | sed -rne "s,^Version: ([0-9.]+)(~|-)(.*),\1,p")
 
 %:
-	dh $@ --buildsystem=cmake --parallel --with python2,python3
+	dh $@ --buildsystem=cmake --parallel --with python3
 
 # tests cannot be run in parallel
 override_dh_auto_test:
@@ -18,6 +18,10 @@ override_dh_auto_test:
 	# packages that were built to be installed.
 	#dh_auto_test -O--buildsystem=cmake -O--no-parallel
 
+# Get the python scripts to use python3 by replacinge shebang /usr/bin/python 
+override_dh_python3:
+	dh_python3 --shebang=/usr/bin/python3
+
 # FIXME: LLVM_DEFINITIONS is broken somehow in LLVM cmake upstream
 override_dh_auto_configure:
-	dh_auto_configure -- -DREVISION_LAST=$(UPSTREAM_VERSION) -DREVISION=$(UPSTREAM_VERSION) -DLLVM_DEFINITIONS="-D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" -DPYTHON_CMD="python2;python3"
+	dh_auto_configure -- -DREVISION_LAST=$(UPSTREAM_VERSION) -DREVISION=$(UPSTREAM_VERSION) -DLLVM_DEFINITIONS="-D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" -DPYTHON_CMD="python3"


### PR DESCRIPTION
Build changes so that bcc uses python3 instead of python2.