### PR TITLE
TOOL-16724 bcc: build fails when using "--parallel" on Delphix buildserver

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ DEBIAN_REVISION := $(shell dpkg-parsechangelog | sed -rne "s,^Version: ([0-9.]+)
 UPSTREAM_VERSION := $(shell dpkg-parsechangelog | sed -rne "s,^Version: ([0-9.]+)(~|-)(.*),\1,p")
 
 %:
-	dh $@ --buildsystem=cmake --parallel --with python3
+	dh $@ --buildsystem=cmake --with python3
 
 # tests cannot be run in parallel
 override_dh_auto_test:


### PR DESCRIPTION
I don't understand the root cause, but when doing the build in parallel (i.e. `make -j2`), it fails when running on the Delphix based buildserver. This change modifies the build, such that we always use `make -j1`; obviously this isn't ideal, but until we root cause a fix the underlying problem, this would at least allow us to build on the Delphix buildserver.

As one might expect, this does increase the time to build the package by about 2x; I don't think this is a big deal, since we don't actually build this package very often, and the total time to build is still "reasonable" (i.e. ~20 mins).

Lastly, we haven't synced our bcc codebase with upstream in quite a while, so we might inherit a fix for this parallel building issue when we do that sync. At that time, we could look at adding back the "--parallel" flag, to see if the build would succeed with the updated code.