### PR TITLE
DLPX-88488 profile is missing stack traces

### DIFF
--- a/tools/profile.py
+++ b/tools/profile.py
@@ -25,6 +25,7 @@
 # 15-Jul-2016   Brendan Gregg   Created this.
 # 20-Oct-2016      "      "     Switched to use the new 4.9 support.
 # 26-Jan-2019      "      "     Changed to exclude CPU idle by default.
+# 11-Apr-2023   Rocky Xing      Added option to increase hash storage size.
 
 from __future__ import print_function
 from bcc import BPF, PerfType, PerfSWConfig
@@ -104,6 +105,9 @@ parser.add_argument("-I", "--include-idle", action="store_true",
     help="include CPU idle stacks")
 parser.add_argument("-f", "--folded", action="store_true",
     help="output folded format, one line per stack (for flame graphs)")
+parser.add_argument("--hash-storage-size", default=40960,
+    type=positive_nonzero_int,
+    help="the number of hash keys that can be stored and (default %(default)s)")
 parser.add_argument("--stack-storage-size", default=16384,
     type=positive_nonzero_int,
     help="the number of unique stack traces that can be stored and "
@@ -146,7 +150,7 @@ struct key_t {
     int kernel_stack_id;
     char name[TASK_COMM_LEN];
 };
-BPF_HASH(counts, struct key_t);
+BPF_HASH(counts, struct key_t, u64, HASH_STORAGE_SIZE);
 BPF_STACK_TRACE(stack_traces, STACK_STORAGE_SIZE);
 
 // This code gets a bit complex. Probably not suitable for casual hacking.
@@ -226,6 +230,7 @@ else:
 bpf_text = bpf_text.replace('THREAD_FILTER', thread_filter)
 
 # set stack storage size
+bpf_text = bpf_text.replace('HASH_STORAGE_SIZE', str(args.hash_storage_size))
 bpf_text = bpf_text.replace('STACK_STORAGE_SIZE', str(args.stack_storage_size))
 
 # handle stack args
@@ -306,6 +311,7 @@ def aksym(addr):
 missing_stacks = 0
 has_collision = False
 counts = b.get_table("counts")
+htab_full = args.hash_storage_size == len(counts)
 stack_traces = b.get_table("stack_traces")
 for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
     # handle get_stackid errors
@@ -375,4 +381,9 @@ if missing_stacks > 0:
         " Consider increasing --stack-storage-size."
     print("WARNING: %d stack traces could not be displayed.%s" %
         (missing_stacks, enomem_str),
+        file=stderr)
+
+# check whether hash table is full
+if htab_full:
+    print("WARNING: hash table full. Consider increasing --hash-storage-size.",
         file=stderr)

--- a/tools/profile_example.txt
+++ b/tools/profile_example.txt
@@ -715,7 +715,7 @@ USAGE message:
 
 # ./profile -h
 usage: profile.py [-h] [-p PID | -L TID] [-U | -K] [-F FREQUENCY | -c COUNT]
-                  [-d] [-a] [-I] [-f]
+                  [-d] [-a] [-I] [-f] [--hash-storage-size HASH_STORAGE_SIZE]
                   [--stack-storage-size STACK_STORAGE_SIZE] [-C CPU]
                   [--cgroupmap CGROUPMAP] [--mntnsmap MNTNSMAP]
                   [duration]
@@ -727,8 +727,10 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -p PID, --pid PID     profile process with this PID only
-  -L TID, --tid TID     profile thread with this TID only
+  -p PID, --pid PID     profile process with one or more comma separated PIDs
+                        only
+  -L TID, --tid TID     profile thread with one or more comma separated TIDs
+                        only
   -U, --user-stacks-only
                         show stacks from user space only (no kernel space
                         stacks)
@@ -744,6 +746,9 @@ optional arguments:
   -I, --include-idle    include CPU idle stacks
   -f, --folded          output folded format, one line per stack (for flame
                         graphs)
+  --hash-storage-size HASH_STORAGE_SIZE
+                        the number of hash keys that can be stored and
+                        (default 40960)
   --stack-storage-size STACK_STORAGE_SIZE
                         the number of unique stack traces that can be stored
                         and displayed (default 16384)


### PR DESCRIPTION
Clean cherrypick of https://github.com/delphix/bcc/pull/16/commits/b2e9c36941eee58005120e5e34e12d9e9ecd5783
Testing: ab-pre-push passed

Ran the following to figure out number of entries on a 4 core system
without the change:
"""
delphix@ip-10-110-214-21:/var/delphix/server/log/stats$ grep -v '^-' profile_3600.log  | grep -o ' [0-9]*$' | paste -s -d+ - | bc
721214
"""
721214/(60*60*4*99) = ~50% hit rate

with the change:
"""
delphix@ip-10-110-238-208:/var/delphix/server/log/stats$ grep -v '2023-11-01' profile_3600.log  | grep -o ' [0-9]*$' | paste -s -d+ - | bc 
1237787
"""
1237787/(60*60*4*99) = ~80% hit rate

I doubled the default hash to 81920 and we got to 83% hit rate, does not seem like we gain too much with increasing the hash size.
